### PR TITLE
Don't reject null for optional fields

### DIFF
--- a/src/main/scala/io/apibuilder/validation/JsonValidator.scala
+++ b/src/main/scala/io/apibuilder/validation/JsonValidator.scala
@@ -71,14 +71,24 @@ case class JsonValidator(val service: Service) {
 
   private[this] def toObject(prefix: String, js: JsValue): Either[Seq[String], JsObject] = {
     js match {
-      case v: JsArray => {
+      case _: JsArray => {
         Left(Seq(s"$prefix must be an object and not an array"))
       }
-      case v: JsBoolean => Left(Seq(s"$prefix must be an object and not a boolean"))
+      case _: JsBoolean => Left(Seq(s"$prefix must be an object and not a boolean"))
       case JsNull => Left(Seq(s"$prefix must be an object and not null"))
-      case v: JsNumber => Left(Seq(s"$prefix must be an object and not a number"))
-      case v: JsObject => Right(v)
-      case v: JsString => Left(Seq(s"$prefix must be an object and not a string"))
+      case _: JsNumber => Left(Seq(s"$prefix must be an object and not a number"))
+      case v: JsObject => Right(
+        // Remove null fields as there is nothing to validate there
+        JsObject(
+          v.value.filter { case (k, v) =>
+              v match {
+                case JsNull => false
+                case _ => true
+              }
+          }
+        )
+      )
+      case _: JsString => Left(Seq(s"$prefix must be an object and not a string"))
     }
   }
 

--- a/src/test/scala/io/apibuilder/validation/JsonValidatorSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/JsonValidatorSpec.scala
@@ -342,26 +342,6 @@ class JsonValidatorSpec extends FunSpec with Matchers {
     )
   }
 
-  it("Properly validates null in place of array") {
-    val form = Json.obj(
-      "number" -> 123,
-      "cvv" -> 456,
-      "expiration_month" -> "01",
-      "expiration_year" -> "2019",
-      "name" -> "Joe Smith",
-      "address" -> Json.obj(
-        "streets" -> JsNull
-      )
-    )
-
-    validator.validate("card_form", form) match {
-      case Left(errors) => errors should equal(
-        Seq("Type 'card_form' field 'address' of type '[string]': must be an array and not null")
-      )
-      case Right(js) => sys.error("Expected form to NOT validate")
-    }
-  }
-
   it("Properly reports errors on js objects") {
     val form = Json.obj(
       "name" -> "",
@@ -412,6 +392,22 @@ class JsonValidatorSpec extends FunSpec with Matchers {
         Seq("Type 'merchant_of_record_authorization_form' field 'order_number' must be a string and not an array")
       )
       case Right(_) => sys.error("Expected validation error")
+    }
+  }
+
+  it("accept null as optional") {
+    val form = Json.obj(
+      "description" -> JsNull,
+      "number" -> "1",
+      "locale" -> "en_US",
+      "name" -> "test",
+      "currency" -> "USD",
+      "price" -> 10
+    )
+
+    validator.validate("item_form", form) match {
+      case Left(errors) => sys.error(s"Expected form to validate but got: $errors")
+      case Right(_) => // no-op
     }
   }
 }


### PR DESCRIPTION
- If a model has an optional field, and the JSON document sent looks like:
    { "description": null }
    We were returning a validation error. This change removes null values from
    the incoming JSON to validate (and thus optional fields sent as null will be
    allowed). Required fields sent as null will be validated as missing data