### PR TITLE
Explicitly convert null values to JsNull

### DIFF
--- a/src/main/scala/io/apibuilder/validation/FormData.scala
+++ b/src/main/scala/io/apibuilder/validation/FormData.scala
@@ -240,6 +240,7 @@ object FormData {
 
   private[this] def toJsPrimitive(value: String): JsValue = {
     value match {
+      case null => JsNull
       case "true" => JsBoolean(true)
       case "false" => JsBoolean(false)
       case other => {

--- a/src/test/scala/io/apibuilder/validation/FormDataSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/FormDataSpec.scala
@@ -107,7 +107,8 @@ class FormDataSpec extends FunSpec with Matchers {
       "one[two][three][five]" -> Seq("wow"),
       "arr[][arr2][]" -> Seq("fruit", "vegetables"),
       "tags[]" -> Seq("foo", "bar"),
-      "yikes" -> Seq("yes", "no")
+      "yikes" -> Seq("yes", "no"),
+      "anEmptyString" -> Seq(null)
     )
 
     it("returns JsValue") {
@@ -155,6 +156,11 @@ class FormDataSpec extends FunSpec with Matchers {
         case JsSuccess(succ,_) => succ should be(Seq("yes", "no"))
         case JsError(_) => assert(false)
       }
+    }
+
+    it("handles empty strings") {
+      val res = FormData.toJson(data).fields.find(_._1 == "anEmptyString")
+      res should be(Some("anEmptyString" -> JsNull))
     }
   }
 }


### PR DESCRIPTION
Previously, `null` values were falling through to the "other" case and thus converted to `JsString(null)`.  This would then pass validation here: 
https://github.com/apicollective/apibuilder-validation/blob/a15f40396fbc5cd9a1c596ae87547637248383d2/src/main/scala/io/apibuilder/validation/JsonValidator.scala#L234
which would subsequently fail when being unmarshalled into a model.