### PR TITLE
encode with index

### DIFF
--- a/src/main/scala/io/apibuilder/validation/FormData.scala
+++ b/src/main/scala/io/apibuilder/validation/FormData.scala
@@ -60,6 +60,33 @@ object FormData {
     }
   }
 
+  /**
+    * Converts the specified js value into a url form encoded string,
+    * recursively through all types.
+    *
+    * @param keys Keeps track of the top level keys we are parsing to
+    *             build up nested keys (e.g. user[first] for maps)
+    */
+  def toEncodedWithIndex(js: JsValue, keys: Seq[String] = Nil, index: Int = 0): String = {
+    js match {
+      case o: JsObject => {
+        o.value.map { case (key, value) =>
+          toEncodedWithIndex(value, keys ++ Seq(key), index)
+        }.mkString("&")
+      }
+      case o: JsArray => {
+        o.value.zipWithIndex.map { case (v, i) =>
+          toEncodedWithIndex(v, keys, i)
+        }.mkString("&")
+      }
+      case o: JsString => encodeWithIndex(o.value, keys, index)
+      case o: JsBoolean => encodeWithIndex(o.value.toString, keys, index)
+      case o: JsNumber => encodeWithIndex(o.value.toString, keys, index)
+      case JsNull => encodeWithIndex("", keys, index)
+      case other => encodeWithIndex(other.toString, keys, index)
+    }
+  }
+
   private[this] def encode(value: String, keys: Seq[String] = Nil): String = {
     keys.toList match {
       case Nil => value
@@ -69,11 +96,28 @@ object FormData {
     }
   }
 
+  private[this] def encodeWithIndex(value: String, keys: Seq[String] = Nil, index: Int = 0): String = {
+    keys.toList match {
+      case Nil => value
+      case one :: rest => {
+        s"%s=%s".format(buildKeyWithIndex(one, rest, index), value)
+      }
+    }
+  }
+
   @scala.annotation.tailrec
   private[this] def buildKey(result: String, values: Seq[String]): String = {
     values.toList match {
       case Nil => result
       case one :: rest => buildKey(s"$result[$one]", rest)
+    }
+  }
+
+  @scala.annotation.tailrec
+  private[this] def buildKeyWithIndex(result: String, values: Seq[String], index: Int = 0): String = {
+    values.toList match {
+      case Nil => result
+      case one :: rest => buildKeyWithIndex(s"$result[$index][$one]", rest, index + 1)
     }
   }
 

--- a/src/main/scala/io/apibuilder/validation/FormData.scala
+++ b/src/main/scala/io/apibuilder/validation/FormData.scala
@@ -1,6 +1,6 @@
 package io.apibuilder.validation
 
-import java.net.URLDecoder
+import java.net.{URLDecoder, URLEncoder}
 
 import play.api.libs.json._
 
@@ -96,11 +96,13 @@ object FormData {
     }
   }
 
+  private[this] def encodeSpacesToPercent20(s: String) = s.replaceAll(" ","%20")
+
   private[this] def encodeWithIndex(value: String, keys: Seq[String] = Nil, index: Int = 0): String = {
     keys.toList match {
-      case Nil => value
+      case Nil => encodeSpacesToPercent20(value)
       case one :: rest => {
-        s"%s=%s".format(buildKeyWithIndex(one, rest, index), value)
+        s"%s=%s".format(buildKeyWithIndex(one, rest, index), encodeSpacesToPercent20(value))
       }
     }
   }

--- a/src/test/resources/querystring/array_with_indexed_object.fixture
+++ b/src/test/resources/querystring/array_with_indexed_object.fixture
@@ -1,0 +1,17 @@
+locations[0][state]=New York
+locations[0][city]=Brooklyn
+locations[1][state]=New Jersey
+locations[1][city]=Hoboken
+
+{
+  "locations": [
+    {
+      "state": "New York",
+      "city": "Brooklyn"
+    },
+    {
+      "state": "New Jersey",
+      "city": "Hoboken"
+    }
+  ]
+}

--- a/src/test/scala/io/apibuilder/validation/Fixture.scala
+++ b/src/test/scala/io/apibuilder/validation/Fixture.scala
@@ -3,13 +3,15 @@ package io.apibuilder.validation
 import java.io.File
 import java.net.URLEncoder
 
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json.{JsObject, Json}
 
 case class Fixture(params: Seq[(String, String)], expected: JsObject) {
 
   def rawQueryString: String = {
     params.map { case (k,v) => s"$k=" + URLEncoder.encode(v, "UTF-8") }.mkString("&")
   }
+
+  def urlEncodedString = rawQueryString.replaceAll("\\+","%20")
 
 }
 

--- a/src/test/scala/io/apibuilder/validation/FormDataSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/FormDataSpec.scala
@@ -1,5 +1,7 @@
 package io.apibuilder.validation
 
+import java.io.File
+
 import org.scalatest.{FunSpec, Matchers}
 import play.api.libs.json._
 
@@ -164,63 +166,26 @@ class FormDataSpec extends FunSpec with Matchers {
     }
 
     it("parses values inside array of arrays index by outer array") {
-      val number1 = 123
-      val quantity1 = 31
-      val index1 = 0
-      val number2 = 999
-      val quantity2 = 5
-      val index2 = 1
-      val number3 = 800
-      val quantity3 = 1
-      val index3 = 2
+      val file = new File("src/test/resources/querystring/array_with_indexed_object.fixture")
+      val fixture = Fixture.load(file)
 
-      val data =
-        s"""
-            items[$index1][number]=$number1
-           &items[$index1][quantity]=$quantity1
-           &items[$index2][number]=$number2
-           &items[$index2][quantity]=$quantity2
-           &items[$index3][number]=$number3
-           &items[$index3][quantity]=$quantity3
-          """.stripMargin.trim.replaceAll(" ", "").replaceAll("\\n","")
+      val actualJson = FormData.parseEncodedToJsObject(fixture.urlEncodedString)
 
-      val actualJson = FormData.parseEncodedToJsObject(data)
-
-      actualJson \ "items" \ index1 \ "number" should be(JsDefined(JsNumber(number1)))
-      actualJson \ "items" \ index1 \ "quantity" should be(JsDefined(JsNumber(quantity1)))
-      actualJson \ "items" \ index2 \ "number" should be(JsDefined(JsNumber(number2)))
-      actualJson \ "items" \ index2 \ "quantity" should be(JsDefined(JsNumber(quantity2)))
-      actualJson \ "items" \ index3 \ "number" should be(JsDefined(JsNumber(number3)))
-      actualJson \ "items" \ index3 \ "quantity" should be(JsDefined(JsNumber(quantity3)))
-
+      actualJson \ "locations" \ 0 \ "state" should be(JsDefined(JsString("New York")))
+      actualJson \ "locations" \ 0 \ "city" should be(JsDefined(JsString("Brooklyn")))
+      actualJson \ "locations" \ 1 \ "state" should be(JsDefined(JsString("New Jersey")))
+      actualJson \ "locations" \ 1 \ "city" should be(JsDefined(JsString("Hoboken")))
     }
 
     it("generates array of arrays indexed by outer array") {
-      val number1 = 123
-      val quantity1 = 31
-      val index1 = 0
-      val number2 = 999
-      val quantity2 = 5
-      val index2 = 1
-      val number3 = 800
-      val quantity3 = 1
-      val index3 = 2
+      val file = new File("src/test/resources/querystring/array_with_indexed_object.fixture")
+      val fixture = Fixture.load(file)
+      val json = fixture.expected
+      val expectedQueryString = fixture.urlEncodedString
 
-      val data =
-        s"""
-            items[$index1][quantity]=$quantity1
-           &items[$index1][number]=$number1
-           &items[$index2][quantity]=$quantity2
-           &items[$index2][number]=$number2
-           &items[$index3][number]=$number3
-           &items[$index3][quantity]=$quantity3
-          """.stripMargin.trim.replaceAll(" ", "").replaceAll("\\n","")
+      val actualEncodedString: String = FormData.toEncodedWithIndex(json)
 
-      val actualEncodedString: String = FormData.toEncodedWithIndex(FormData.parseEncodedToJsObject(data))
-      val expectedEncodedString = data
-
-      actualEncodedString should be (expectedEncodedString)
-      println(actualEncodedString)
+      actualEncodedString should be (expectedQueryString)
     }
   }
 }


### PR DESCRIPTION
**To be able to encode arrays with indexed fields**

**Example:** 

**Following JSON**
```
"items": [
   { "number": 123, "quantity": 5 },
   { "number": 456, "quantity": 10 }
]
```
**Is encoded into following Query String**
```
items[0][number]=123&items[0][quantity]=5&items[1][number]=456&items[1][quantity]=10
```
