### PR TITLE
Expose the type's service in ApibuilderType rather than just the namespace (breaking)

### DIFF
--- a/src/main/scala/io/apibuilder/validation/ApibuilderType.scala
+++ b/src/main/scala/io/apibuilder/validation/ApibuilderType.scala
@@ -3,11 +3,11 @@ package io.apibuilder.validation
 import io.apibuilder.spec.v0.models
 
 sealed trait ApibuilderType {
-  def nameSpace: String
+  def service: models.Service
 }
 
 object ApibuilderType {
-  case class Enum(nameSpace: String, enum: models.Enum) extends ApibuilderType
-  case class Model(nameSpace: String, model: models.Model) extends ApibuilderType
-  case class Union(nameSpace: String, union: models.Union) extends ApibuilderType
+  case class Enum(service: models.Service, enum: models.Enum) extends ApibuilderType
+  case class Model(service: models.Service, model: models.Model) extends ApibuilderType
+  case class Union(service: models.Service, union: models.Union) extends ApibuilderType
 }

--- a/src/main/scala/io/apibuilder/validation/JsonValidator.scala
+++ b/src/main/scala/io/apibuilder/validation/JsonValidator.scala
@@ -46,13 +46,13 @@ case class JsonValidator(services: Seq[Service]) {
 
   private[this] def findType(service: Service, typeName: String): Option[ApibuilderType] = {
     service.enums.find(_.name == typeName) match {
-      case Some(e) => Some(ApibuilderType.Enum(service.namespace, e))
+      case Some(e) => Some(ApibuilderType.Enum(service, e))
       case None => {
         service.models.find(_.name == typeName) match {
-          case Some(m) => Some(ApibuilderType.Model(service.namespace, m))
+          case Some(m) => Some(ApibuilderType.Model(service, m))
           case None => {
             service.unions.find(_.name == typeName) match {
-              case Some(u) => Some(ApibuilderType.Union(service.namespace, u))
+              case Some(u) => Some(ApibuilderType.Union(service, u))
               case None => None
             }
           }


### PR DESCRIPTION
This allows access to other fields of the service (eg. version, organization, etc.)