### PR TITLE
Change jar namespace to io.apibuilder

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "apibuilder-validation"
 
-organization := "io.flow"
+organization := "io.apibuilder"
 
 scalaVersion in ThisBuild := "2.12.8"
 


### PR DESCRIPTION
All the classes in the library are in the `io.apibuilder` package. It should be consistent with the jar namespace. I'm not sure what other steps need to be taken before this can be merged.