### PR TITLE
Add order.txt file

### DIFF
--- a/src/main/scala/io/apibuilder/validation/util/FileOrder.scala
+++ b/src/main/scala/io/apibuilder/validation/util/FileOrder.scala
@@ -1,0 +1,40 @@
+package io.apibuilder.validation.util
+
+import java.io.File
+
+import io.apibuilder.validation.zip.FileUtil
+
+/**
+  * Reads a file named "order.txt" in the zip file and uses that
+  * to sort files in the order in which they should be loaded
+  * into the MultiService class
+ */
+case class FileOrder(file: Option[File]) {
+  private[this] val nameToOrder: Map[String, Int] = file match {
+    case None => Map.empty
+    case Some(f) => {
+      Map(
+        FileUtil
+          .readFileAsString(f)
+          .split("\n")
+          .map(_.trim)
+          .filterNot(_.isEmpty)
+          .zipWithIndex.map { case (name, i) =>
+            name.trim.toLowerCase() -> i
+        }: _*
+      )
+    }
+  }
+
+  def sort(names: Seq[String]): List[String] = {
+    names.sortBy(sortOrder).toList
+  }
+
+  def sortOrder(fileName: String): (Int, String) = {
+    val lower = fileName.trim.toLowerCase()
+    (
+      nameToOrder.getOrElse(lower, Integer.MAX_VALUE),
+      lower
+    )
+  }
+}

--- a/src/main/scala/io/apibuilder/validation/zip/FileUtil.scala
+++ b/src/main/scala/io/apibuilder/validation/zip/FileUtil.scala
@@ -2,7 +2,18 @@ package io.apibuilder.validation.zip
 
 import java.io.{File, PrintWriter}
 
+import scala.io.Source
+
 object FileUtil {
+
+  def readFileAsString(file: File): String = {
+    val source = Source.fromFile(file,  "UTF-8")
+    try {
+      source.mkString("")
+    } finally {
+      source.close()
+    }
+  }
 
   def writeToTempFile(
     contents: String,

--- a/src/main/scala/io/apibuilder/validation/zip/ZipFileReader.scala
+++ b/src/main/scala/io/apibuilder/validation/zip/ZipFileReader.scala
@@ -12,8 +12,15 @@ object ZipFileReader {
   /**
     * Returns true if url path ends with .zip
     */
-  def isZipFile(url: String): Boolean = {
-    url.trim.split("\\?").head.trim.toLowerCase().endsWith(".zip")
+  def isZipFile(name: String): Boolean = endsWithSuffix(name, "zip")
+
+  /**
+    * Returns true if url path ends with .json
+    */
+  def isJsonFile(name: String): Boolean = endsWithSuffix(name, "json")
+
+  private[this] def endsWithSuffix(name: String, suffix: String) = {
+    name.trim.split("\\?").head.trim.toLowerCase().endsWith(s".$suffix")
   }
 
   def fromUrl(url: String): Either[Seq[String], ZipFileReader] = {
@@ -32,7 +39,7 @@ case class ZipFileReader(inputStream: InputStream) {
   private[this] val destDir: File = Files.createTempDirectory("zipfilereader").toFile
 
   /**
-    * Returns a list of the entries of the zip file
+    * Returns a list of the entries of the zip file (all files ending with .json)
     */
   val entries: Seq[ZipFileEntry] = {
     val all = scala.collection.mutable.ListBuffer[ZipFileEntry]()

--- a/src/test/scala/io/apibuilder/validation/helpers/FileHelpers.scala
+++ b/src/test/scala/io/apibuilder/validation/helpers/FileHelpers.scala
@@ -1,21 +1,11 @@
 package io.apibuilder.validation.helpers
 
 import java.io.File
-
 import io.apibuilder.validation.zip.FileUtil
-
-import scala.io.Source
 
 trait FileHelpers {
 
-  def readFileAsString(file: File): String = {
-    val source = Source.fromFile(file,  "UTF-8")
-    try {
-      source.mkString("")
-    } finally {
-      source.close()
-    }
-  }
+  def readFileAsString(file: File): String = FileUtil.readFileAsString(file)
 
   def writeToTempFile(
     contents: String,

--- a/src/test/scala/io/apibuilder/validation/util/FileOrderSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/util/FileOrderSpec.scala
@@ -1,0 +1,31 @@
+package io.apibuilder.validation.util
+
+import io.apibuilder.validation.helpers
+import org.scalatest.{FunSpec, Matchers}
+
+class FileOrderSpec extends FunSpec with Matchers
+  with helpers.FileHelpers
+{
+  it("sortOrder with no ordering file is alphabetical") {
+    FileOrder(None).sort(Seq("b", "a")) should equal(
+      List("a", "b")
+    )
+  }
+
+  it("sortOrder respects ordering file") {
+    FileOrder(
+      Some(writeToTempFile(contents = "b\na"))
+    ).sort(Seq("b", "a")) should equal(
+      List("b", "a")
+    )
+  }
+
+  it("sortOrder respects ordering file for entries in it, alphabetical for rest") {
+    FileOrder(
+      Some(writeToTempFile(contents = "c"))
+    ).sort(Seq("c", "b", "a")) should equal(
+      List("c", "a", "b")
+    )
+  }
+
+}

--- a/src/test/scala/io/apibuilder/validation/zip/ZipFileSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/zip/ZipFileSpec.scala
@@ -8,6 +8,20 @@ import org.scalatest.{FunSpec, Matchers}
 class ZipFileSpec extends FunSpec with Matchers
   with helpers.FileHelpers
 {
+  it("isZipFile") {
+    ZipFileReader.isZipFile("foo.zip") should be(true)
+    ZipFileReader.isZipFile("foo.ZIP") should be(true)
+    ZipFileReader.isZipFile(" foo.zip ") should be(true)
+    ZipFileReader.isZipFile(" foo.csv ") should be(false)
+  }
+
+  it("isJsonFile") {
+    ZipFileReader.isJsonFile("foo.json") should be(true)
+    ZipFileReader.isJsonFile("foo.JSON") should be(true)
+    ZipFileReader.isJsonFile(" foo.json ") should be(true)
+    ZipFileReader.isJsonFile(" foo.csv ") should be(false)
+  }
+
   it("withFile defaults to file name") {
     val tmp = File.createTempFile("foo", "json")
     val zip = ZipFileBuilder().withFile(tmp).build()


### PR DESCRIPTION
- When loading from a zip file, allows the user to specify the exact
   order in which the files should be loaded. All other files are
   loaded in alphabetical (case insensitive) order