### PR TITLE
MultiService: Refactor to avoid ambiguity. Resolved types need to include their service

### DIFF
--- a/src/main/scala/io/apibuilder/validation/ApiBuilderOperation.scala
+++ b/src/main/scala/io/apibuilder/validation/ApiBuilderOperation.scala
@@ -1,0 +1,8 @@
+package io.apibuilder.validation
+
+import io.apibuilder.spec.v0.models.{Operation, Service}
+
+case class ApiBuilderOperation(service: Service, operation: Operation)
+
+
+

--- a/src/main/scala/io/apibuilder/validation/ApiBuilderService.scala
+++ b/src/main/scala/io/apibuilder/validation/ApiBuilderService.scala
@@ -27,7 +27,7 @@ case class ApiBuilderService(
     operation(method, path).flatMap(_.body.map(_.`type`))
   }
 
-  def findType(name: String): Option[ApibuilderType] = {
+  def findType(name: String): Option[ApiBuilderType] = {
     validator.findType(name, defaultNamespace = Some(service.namespace)).headOption
   }
 

--- a/src/main/scala/io/apibuilder/validation/ApiBuilderType.scala
+++ b/src/main/scala/io/apibuilder/validation/ApiBuilderType.scala
@@ -2,7 +2,7 @@ package io.apibuilder.validation
 
 import io.apibuilder.spec.v0.models
 
-sealed trait ApibuilderType {
+sealed trait ApiBuilderType {
 
   def service: models.Service
 
@@ -19,16 +19,16 @@ sealed trait ApibuilderType {
   protected def typeDiscriminator: String
 }
 
-object ApibuilderType {
-  case class Enum(service: models.Service, enum: models.Enum) extends ApibuilderType {
+object ApiBuilderType {
+  case class Enum(service: models.Service, enum: models.Enum) extends ApiBuilderType {
     override val typeName: TypeName = TypeName.parse(name = enum.name, defaultNamespace = service.namespace)
     override val typeDiscriminator = "enums"
   }
-  case class Model(service: models.Service, model: models.Model) extends ApibuilderType {
+  case class Model(service: models.Service, model: models.Model) extends ApiBuilderType {
     override val typeName: TypeName = TypeName.parse(name = model.name, defaultNamespace = service.namespace)
     override val typeDiscriminator = "models"
   }
-  case class Union(service: models.Service, union: models.Union) extends ApibuilderType {
+  case class Union(service: models.Service, union: models.Union) extends ApiBuilderType {
     override val typeName: TypeName = TypeName.parse(name = union.name, defaultNamespace = service.namespace)
     override val typeDiscriminator = "unions"
   }

--- a/src/main/scala/io/apibuilder/validation/JsonValidator.scala
+++ b/src/main/scala/io/apibuilder/validation/JsonValidator.scala
@@ -106,9 +106,9 @@ case class JsonValidator(services: Seq[Service]) {
   }
 
   def validateType(
-                    typ: ApiBuilderType,
-                    js: JsValue,
-                    prefix: Option[String] = None
+    typ: ApiBuilderType,
+    js: JsValue,
+    prefix: Option[String] = None
   ): Either[Seq[String], JsValue] = {
     typ match {
       case e: ApiBuilderType.Enum => {

--- a/src/main/scala/io/apibuilder/validation/JsonValidator.scala
+++ b/src/main/scala/io/apibuilder/validation/JsonValidator.scala
@@ -43,9 +43,7 @@ case class JsonValidator(services: Seq[Service]) {
 
   def findType(defaultNamespace: String, name: String): Seq[ApiBuilderType] = {
     val typeName = TypeName.parse(defaultNamespace = defaultNamespace, name = name)
-    println(s"typeName: $typeName")
     services.filter(_.namespace.equalsIgnoreCase(typeName.namespace)).flatMap { service =>
-      println(s"SERVICE: ${service.namespace}")
       findType(service, typeName.name)
     }
   }

--- a/src/main/scala/io/apibuilder/validation/JsonValidator.scala
+++ b/src/main/scala/io/apibuilder/validation/JsonValidator.scala
@@ -77,10 +77,8 @@ case class JsonValidator(services: Seq[Service]) {
     defaultNamespace: Option[String],
     prefix: Option[String] = None
   ): Either[Seq[String], JsValue] = {
-    println(s"validate($typeName, $js, $defaultNamespace)")
     findType(typeName, defaultNamespace = defaultNamespace).toList match {
       case Nil => {
-        println(" - not found")
         // may be a primitive type like 'string'
         validateApiBuilderType(
           prefix.getOrElse(typeName),
@@ -91,14 +89,10 @@ case class JsonValidator(services: Seq[Service]) {
       }
 
       case typ :: Nil => {
-        println(" - found: $typ")
-
         validateType(typ, js, prefix)
       }
 
       case multiple => {
-        println(s" - found multiple: ${multiple.map(_.qualified)}")
-
         // multiple types matches - insufficient data to validate
         Right(js)
       }

--- a/src/main/scala/io/apibuilder/validation/JsonValidator.scala
+++ b/src/main/scala/io/apibuilder/validation/JsonValidator.scala
@@ -43,7 +43,9 @@ case class JsonValidator(services: Seq[Service]) {
 
   def findType(defaultNamespace: String, name: String): Seq[ApiBuilderType] = {
     val typeName = TypeName.parse(defaultNamespace = defaultNamespace, name = name)
+    println(s"typeName: $typeName")
     services.filter(_.namespace.equalsIgnoreCase(typeName.namespace)).flatMap { service =>
+      println(s"SERVICE: ${service.namespace}")
       findType(service, typeName.name)
     }
   }

--- a/src/main/scala/io/apibuilder/validation/MultiService.scala
+++ b/src/main/scala/io/apibuilder/validation/MultiService.scala
@@ -13,22 +13,26 @@ import play.api.libs.json._
 trait MultiService extends ResponseHelpers {
   def services: Seq[ApiBuilderService]
 
-  def findType(name: String): Seq[ApibuilderType]
-
-  def findType(namespace: String, name: String): Seq[ApibuilderType]
-
   /**
     * If the specified method & path requires a body, returns the type of the body
     */
-  final def bodyTypeFromPath(method: String, path: String): Option[String] = {
-    operation(method, path).flatMap(_.body.map(_.`type`))
+  final def bodyTypeFromPath(method: String, path: String): Option[ApiBuilderType] = {
+    bodyTypeFromPath(Method(method), path)
+  }
+
+  final def bodyTypeFromPath(method: Method, path: String): Option[ApiBuilderType] = {
+    operation(method, path).flatMap(findBodyType)
   }
 
   /**
     * For the given method & path, returns the defined operation, if any
     */
-  final def operation(method: String, path: String): Option[Operation] = {
-    validate(method, path) match {
+  final def operation(method: String, path: String): Option[ApiBuilderOperation] = {
+    operation(Method(method), path)
+  }
+
+  final def operation(method: Method, path: String): Option[ApiBuilderOperation] = {
+    validateOperation(method, path) match {
       case Left(_) => None
       case Right(op) => Some(op)
     }
@@ -38,44 +42,67 @@ trait MultiService extends ResponseHelpers {
     * Validates the js value across all services, upcasting types to
     * match the request method/path as needed.
     */
-  final def upcast(operation: Operation, js: JsValue): Either[Seq[String], JsValue] = {
-    operation.body.map(_.`type`) match {
+  def upcast(apiBuilderOperation: ApiBuilderOperation, js: JsValue): Either[Seq[String], JsValue] = {
+    findBodyType(apiBuilderOperation) match {
       case None => Right(js)
-      case Some(typeName) => upcast(typeName, js)
+      case Some(bodyType) => upcast(bodyType, js)
     }
   }
 
-  final def upcast(method: String, path: String, js: JsValue): Either[Seq[String], JsValue] = {
-    validate(method, path) match {
-      case Left(errors) => Left(errors)
-      case Right(op) => upcast(op, js)
+  def findBodyType(apiBuilderOperation: ApiBuilderOperation): Option[ApiBuilderType] = {
+    apiBuilderOperation.operation.body.flatMap { body =>
+      findType(
+        defaultNamespace = apiBuilderOperation.service.namespace,
+        typeName = body.`type`
+      )
     }
   }
 
   /**
-    * Upcast the json value based on the specified type name
+    * Upcast the json value based on the specified type name, if it is defined. a No-op if not
+    */
+  def upcast(typ: ApiBuilderType, js: JsValue): Either[Seq[String], JsValue]
+
+  final def upcast(method: String, path: String, js: JsValue): Either[Seq[String], JsValue] = {
+    upcast(Method(method), path, js)
+  }
+
+  final def upcast(method: Method, path: String, js: JsValue): Either[Seq[String], JsValue] = {
+    operation(method, path) match {
+      case None => Right(js)
+      case Some(op) => upcast(op, js)
+    }
+  }
+
+  final def upcastType(defaultNamespace: String, typeName: String, js: JsValue): Either[Seq[String], JsValue] = {
+    findType(defaultNamespace = defaultNamespace, typeName = typeName) match {
+      case None => Right(js)
+      case Some(t) => upcast(t, js)
+    }
+  }
+
+  /**
+    * Resolves the type specified
     *
+    * @param defaultNamespace e.g. io.flow.user.v0 - used unless the type name
+    *                         is fully qualified already
     * @param typeName e.g. 'user' - looks up the API Builder type with this name
     *                 and if found, uses that type to validate and upcast the
     *                 JSON. Note if the type is not found, the JSON returned
     *                 is unchanged.
     */
-  def upcast(typeName: String, js: JsValue): Either[Seq[String], JsValue]
+  def findType(defaultNamespace: String, typeName: String): Option[ApiBuilderType]
 
-  def upcast(typ: ApibuilderType, js: JsValue): Either[Seq[String], JsValue]
-
-  /**
-   * Validates that the path is known and the method is supported for the path.
-   * If known, returns the corresponding operation. Otherwise returns a
-   * list of errors.
-   */
-  final def validate(method: String, path: String): Either[Seq[String], Operation] = {
-    validate(Method(method), path)
+  final def validateOperation(method: String, path: String): Either[Seq[String], ApiBuilderOperation] = {
+    validateOperation(Method(method), path)
   }
 
-  def validate(method: Method, path: String): Either[Seq[String], Operation]
-
-  def validate(typ: ApibuilderType, js: JsValue, prefix: Option[String] = None): Either[Seq[String], JsValue]
+  /**
+    * Validates that the path is known and the method is supported for the path.
+    * If known, returns the corresponding operation. Otherwise returns a
+    * list of errors.
+    */
+  def validateOperation(method: Method, path: String): Either[Seq[String], ApiBuilderOperation]
 
 }
 

--- a/src/main/scala/io/apibuilder/validation/MultiServiceImpl.scala
+++ b/src/main/scala/io/apibuilder/validation/MultiServiceImpl.scala
@@ -16,15 +16,15 @@ case class MultiServiceImpl(
 
   private[this] val validator = JsonValidator(services.map(_.service))
 
-  def findType(name: String): Seq[ApibuilderType] = validator.findType(name, defaultNamespace = None)
+  def findType(name: String): Seq[ApiBuilderType] = validator.findType(name, defaultNamespace = None)
 
-  def findType(namespace: String, name: String): Seq[ApibuilderType] = validator.findType(namespace, name)
+  def findType(namespace: String, name: String): Seq[ApiBuilderType] = validator.findType(namespace, name)
 
   def upcast(typeName: String, js: JsValue): Either[Seq[String], JsValue] = {
     validator.validate(typeName, js, defaultNamespace = None)
   }
 
-  def upcast(typ: ApibuilderType, js: JsValue): Either[Seq[String], JsValue] = {
+  def upcast(typ: ApiBuilderType, js: JsValue): Either[Seq[String], JsValue] = {
     validator.validateType(typ, js)
   }
 
@@ -36,9 +36,9 @@ case class MultiServiceImpl(
   }
 
   def validate(
-    typ: ApibuilderType,
-    js: JsValue,
-    prefix: Option[String] = None
+                typ: ApiBuilderType,
+                js: JsValue,
+                prefix: Option[String] = None
   ): Either[Seq[String], JsValue] = {
     validator.validateType(typ, js, prefix)
   }

--- a/src/main/scala/io/apibuilder/validation/MultiServiceImpl.scala
+++ b/src/main/scala/io/apibuilder/validation/MultiServiceImpl.scala
@@ -1,9 +1,6 @@
 package io.apibuilder.validation
 
-import java.util.concurrent.ConcurrentHashMap
-
-import io.apibuilder.spec.v0.models._
-import play.api.libs.json._
+import play.api.libs.json.JsValue
 
 /**
   * Wrapper to work with multiple API Builder services.
@@ -11,90 +8,20 @@ import play.api.libs.json._
   * services define an http path, first one is selected.
   */
 case class MultiServiceImpl(
-  services: Seq[ApiBuilderService]
+  override val services: Seq[ApiBuilderService]
 ) extends MultiService {
 
   private[this] val validator = JsonValidator(services.map(_.service))
 
-  def findType(name: String): Seq[ApiBuilderType] = validator.findType(name, defaultNamespace = None)
-
-  def findType(namespace: String, name: String): Seq[ApiBuilderType] = validator.findType(namespace, name)
-
-  def upcast(typeName: String, js: JsValue): Either[Seq[String], JsValue] = {
-    validator.validate(typeName, js, defaultNamespace = None)
+  override def findType(defaultNamespace: String, typeName: String): Option[ApiBuilderType] = {
+    validator.findType(
+      name = typeName,
+      defaultNamespace = Some(defaultNamespace)
+    ).headOption
   }
 
-  def upcast(typ: ApiBuilderType, js: JsValue): Either[Seq[String], JsValue] = {
+  override def upcast(typ: ApiBuilderType, js: JsValue): Either[Seq[String], JsValue] = {
     validator.validateType(typ, js)
   }
 
-  def validate(method: Method, path: String): Either[Seq[String], Operation] = {
-    resolveService(method, path) match {
-      case Left(errors) => Left(errors)
-      case Right(service) => service.validate(method, path)
-    }
-  }
-
-  def validate(
-                typ: ApiBuilderType,
-                js: JsValue,
-                prefix: Option[String] = None
-  ): Either[Seq[String], JsValue] = {
-    validator.validateType(typ, js, prefix)
-  }
-
-  private[this] val resolveServiceCache = new ConcurrentHashMap[String, Either[Seq[String], ApiBuilderService]]()
-
-  /**
-    * resolve the API Builder service defined at the provided method, path.
-    * if no service, return a nice error message. Otherwise invoke
-    * the provided function on the API Builder service.
-    */
-  def resolveService(method: Method, path: String): Either[Seq[String], ApiBuilderService] = {
-    resolveServiceCache.computeIfAbsent(
-      s"$method$path",
-      _ => { doResolveService(method, path) }
-    )
-  }
-
-  private[this] def doResolveService(method: Method, path: String): Either[Seq[String], ApiBuilderService] = {
-    services.filter { s =>
-      s.isDefinedAt(method = method, path = path)
-    } match {
-      case Nil => {
-        services.find(_.isPathDefinedAt(path)) match {
-          case None => {
-            Left(Seq(s"HTTP path '$path' is not defined"))
-          }
-
-          case Some(s) => s.validate(method, path) match {
-            case Left(errors) => Left(errors)
-            case Right(_) => Right(s)
-          }
-        }
-      }
-      case one :: Nil => Right(one)
-
-      case multiple => {
-        // If we find a non dynamic path in any service, return that one.
-        // Otherwise return the first matching service. This handles ambiguity:
-        //   - service 1 defines POST /:organization/tokens
-        //   - service 2 defines POST /users/tokens
-        // We want to return service 2 when the path is /users/tokens
-        Right(
-          multiple.find { s =>
-            s.validate(method, path) match {
-              case Right(op) if Route.isStatic(op.path) => true
-              case _ => false
-            }
-          }.getOrElse {
-            multiple.head
-          }
-        )
-      }
-    }
-  }
-
 }
-
-

--- a/src/main/scala/io/apibuilder/validation/PathNormalizer.scala
+++ b/src/main/scala/io/apibuilder/validation/PathNormalizer.scala
@@ -10,7 +10,7 @@ object PathNormalizer {
   }
 
   def apply(multi: MultiService): PathNormalizer = {
-    apply(multi.services.flatMap(_.service.resources.flatMap(_.operations)))
+    apply(multi.allOperations().map(_.operation))
   }
 
   def apply(service: Service): PathNormalizer = {

--- a/src/main/scala/io/apibuilder/validation/ResponseHelpers.scala
+++ b/src/main/scala/io/apibuilder/validation/ResponseHelpers.scala
@@ -4,6 +4,10 @@ import io.apibuilder.spec.v0.models._
 
 trait ResponseHelpers {
 
+  def response(apibuilderOperation: ApiBuilderOperation, responseCode: Int): Option[Response] = {
+    response(apibuilderOperation.operation, responseCode)
+  }
+
   /**
     * Looks up the response for the given status code for this operation, or None
     * if there is no response documented for the status code
@@ -28,6 +32,10 @@ trait ResponseHelpers {
         }
       }
     }
+  }
+
+  def validateResponseCode(apiBuilderOperation: ApiBuilderOperation, responseCode: Int): Either[String, Response] = {
+    validateResponseCode(apiBuilderOperation.operation, responseCode)
   }
 
   /**

--- a/src/main/scala/io/apibuilder/validation/ServiceResolver.scala
+++ b/src/main/scala/io/apibuilder/validation/ServiceResolver.scala
@@ -1,0 +1,48 @@
+package io.apibuilder.validation
+
+import java.util.concurrent.ConcurrentHashMap
+
+import io.apibuilder.spec.v0.models._
+
+case class ServiceResolver(services: List[ApiBuilderService]) {
+
+  private[this] val cache = new ConcurrentHashMap[String, Option[ApiBuilderService]]()
+
+  /**
+    * resolve the API Builder service defined at the provided method, path.
+    * if no service, return a nice error message. Otherwise invoke
+    * the provided function on the API Builder service.
+    */
+  def resolve(method: Method, path: String): Option[ApiBuilderService] = {
+    cache.computeIfAbsent(
+      s"$method$path",
+      _ => { doResolveService(method, path) }
+    )
+  }
+
+  private[this] def doResolveService(method: Method, path: String): Option[ApiBuilderService] = {
+    services.filter { s =>
+      s.isDefinedAt(method = method, path = path)
+    } match {
+      case Nil => None
+      case one :: Nil => Some(one)
+      case multiple => {
+        // If we find a static path in any service, return that one.
+        // Otherwise return the first matching service. This handles ambiguity:
+        //   - service 1 defines POST /:organization/tokens
+        //   - service 2 defines POST /users/tokens
+        // We want to return service 2 when the path is /users/tokens
+        multiple.find { s =>
+          s.validate(method, path) match {
+            case Right(op) if Route.isStatic(op.path) => true
+            case _ => false
+          }
+        }.orElse {
+          multiple.headOption
+        }
+      }
+    }
+  }
+}
+
+

--- a/src/test/scala/io/apibuilder/validation/ApiBuilderTypeSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/ApiBuilderTypeSpec.scala
@@ -4,12 +4,12 @@ import io.apibuilder.spec.v0.models.{Enum, Model, Union}
 import io.apibuilder.validation.helpers.Helpers
 import org.scalatest.{FunSpec, Matchers}
 
-class ApibuilderTypeSpec extends FunSpec with Matchers with Helpers {
+class ApiBuilderTypeSpec extends FunSpec with Matchers with Helpers {
 
   private[this] lazy val service = loadService("flow-api-service.json").service
-  private[this] lazy val enum = ApibuilderType.Enum(service, Enum("gender", "genders", values = Nil))
-  private[this] lazy val model = ApibuilderType.Model(service, Model("user", "users", fields = Nil))
-  private[this] lazy val union = ApibuilderType.Union(service, Union("test", "tests", types = Nil))
+  private[this] lazy val enum = ApiBuilderType.Enum(service, Enum("gender", "genders", values = Nil))
+  private[this] lazy val model = ApiBuilderType.Model(service, Model("user", "users", fields = Nil))
+  private[this] lazy val union = ApiBuilderType.Union(service, Union("test", "tests", types = Nil))
 
   it("typeName") {
     enum.typeName should equal(TypeName("gender", service.namespace))

--- a/src/test/scala/io/apibuilder/validation/JsonValidatorSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/JsonValidatorSpec.scala
@@ -436,7 +436,7 @@ class JsonValidatorSpec extends FunSpec with Matchers with Helpers {
   }
 
   it("understands arrays are required") {
-    apibuilderMultiService.upcast(
+    apibuilderMultiService.upcastOperationBody(
       "POST", "/queries", Json.obj()
     ) should equal(
       Left(Seq("Missing required field for query_form: filters"))

--- a/src/test/scala/io/apibuilder/validation/MultiServiceApicollectiveSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceApicollectiveSpec.scala
@@ -7,7 +7,7 @@ import play.api.libs.json.Json
 class MultiServiceApicollectiveSpec extends FunSpec with Matchers with Helpers {
 
   it("validates imported enums") {
-    apibuilderMultiService.upcast(
+    apibuilderMultiService.upcastOperationBody(
       "POST",
       "/people",
       Json.obj(

--- a/src/test/scala/io/apibuilder/validation/MultiServiceImplSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceImplSpec.scala
@@ -5,7 +5,7 @@ import io.apibuilder.validation.helpers.Helpers
 import play.api.libs.json._
 import org.scalatest.{FunSpec, Matchers}
 
-class MultiServiceImplImplSpec extends FunSpec with Matchers with Helpers {
+class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
 
   private[this] lazy val multi = MultiServiceImpl(
     Seq("flow-api-service.json", "apibuilder-api-service.json").map(loadService)
@@ -29,18 +29,18 @@ class MultiServiceImplImplSpec extends FunSpec with Matchers with Helpers {
   it("operation") {
     multi.operation("POST", "/foo/bar/baz") should be(None)
 
-    val op = multi.operation("POST", "/users").get
+    val op = multi.operation("POST", "/users").get.operation
     op.method should equal(Method.Post)
     op.path should equal("/users")
     op.parameters should be(Nil)
 
-    multi.operation("GET", "/users").get.parameters.map(_.name) should be(
+    multi.operation("GET", "/users").get.operation.parameters.map(_.name) should be(
       Seq("id", "email", "status", "limit", "offset", "sort")
     )
     println(
       multi.operation("GET", "/org/experiences/items").get
     )
-    multi.operation("GET", "/org/experiences/items").get.parameters.map(_.name) should be(
+    multi.operation("GET", "/org/experiences/items").get.operation.parameters.map(_.name) should be(
       Seq("organization", "number", "status", "experience", "country", "ip", "currency", "language", "limit", "offset", "sort")
     )
   }

--- a/src/test/scala/io/apibuilder/validation/MultiServiceImplSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceImplSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FunSpec, Matchers}
 class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
 
   private[this] lazy val multi = MultiServiceImpl(
-    Seq("flow-api-service.json", "apibuilder-api-service.json").map(loadService)
+    List("flow-api-service.json", "apibuilder-api-service.json").map(loadService)
   )
 
   it("loads multiple services") {
@@ -47,7 +47,7 @@ class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
 
   it("validate") {
     // path from flow api
-    multi.upcast(
+    multi.upcastOperationBody(
       "POST",
       "/:organization/webhooks",
       Json.obj("url" -> "https://test.flow.io")
@@ -56,7 +56,7 @@ class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
     )
 
     // path from apidoc api
-    multi.upcast(
+    multi.upcastOperationBody(
       "POST",
       "/:orgKey",
       Json.obj("url" -> "https://test.flow.io")
@@ -67,7 +67,7 @@ class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
 
   it("error on missing array indices") {
     // comes from decoding customer[address][streets][]=33b Bay St
-    multi.upcast(
+    multi.upcastOperationBody(
       "PUT",
       "/:organization/orders/:number",
       Json.parse(
@@ -106,7 +106,7 @@ class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
   it("url query example") {
     val form = FormData.parseEncoded("name=John%20Doe&expiration_month=12&expiration_year=2017&cvv=123&cipher=VnHzBw%2BbaGrKZL0fimklhKupHJeowxK2Mqa9LbECCnb3R%2FxIgS1vr0sFg2mUGsXR7bsNV61UURB91VrWr19V1g%3D%3D&challenge%5Btext%5D=Flow&challenge%5Bcipher%5D=df2BQZykhnTfIVIX6Vg9yjUmyEprz3dLmUYU0O8GeyCZ0t3pn1nXSP7DRDfsZAASwtNupqyYx3G4W%2BmGlWQreg%3D%3D&callback=__flowjsonp0&method=post")
 
-    val js = multi.upcast(
+    val js = multi.upcastOperationBody(
       "POST",
       "/:organization/cards",
       Json.toJson(form)
@@ -124,7 +124,7 @@ class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
       "events" -> 456
     )
 
-    val js = multi.upcast(
+    val js = multi.upcastOperationBody(
       "POST",
       "/:organization/webhooks",
       Json.toJson(form)
@@ -135,7 +135,7 @@ class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
   }
 
   it("offers validation error w/ verb replacement") {
-    multi.upcast(
+    multi.upcastOperationBody(
       "OPTIONS",
       "/:organization/webhooks",
       Json.obj("url" -> "https://test.flow.io", "events" -> "*")
@@ -145,7 +145,7 @@ class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
   }
 
   it("validate union type discriminator") {
-    multi.upcast(
+    multi.upcastOperationBody(
       "POST",
       "/:organization/authorizations",
       Json.obj("discriminator" -> "authorization_form")
@@ -157,7 +157,7 @@ class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
   }
 
   it("validate union type") {
-    multi.upcast(
+    multi.upcastOperationBody(
       "POST",
       "/:organization/authorizations",
       Json.obj(

--- a/src/test/scala/io/apibuilder/validation/MultiServiceImplSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceImplSpec.scala
@@ -19,11 +19,11 @@ class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
     multi.bodyTypeFromPath("POST", "/unknown/path/that/does/not/resolve") should equal(None)
 
     // resources from flow api
-    multi.bodyTypeFromPath("POST", "/users") should equal(Some("user_form"))
-    multi.bodyTypeFromPath("POST", "/:organization/webhooks") should equal(Some("webhook_form"))
+    multi.bodyTypeFromPath("POST", "/users").map(_.name) should equal(Some("user_form"))
+    multi.bodyTypeFromPath("POST", "/:organization/webhooks").map(_.name) should equal(Some("webhook_form"))
 
     // resources from apidoc api
-    multi.bodyTypeFromPath("POST", "/:orgKey") should equal(Some("application_form"))
+    multi.bodyTypeFromPath("POST", "/:orgKey").map(_.name) should equal(Some("application_form"))
   }
 
   it("operation") {
@@ -140,7 +140,9 @@ class MultiServiceImplSpec extends FunSpec with Matchers with Helpers {
       "/:organization/webhooks",
       Json.obj("url" -> "https://test.flow.io", "events" -> "*")
     ) should equal(
-      Left(Seq("HTTP method 'OPTIONS' not supported for path /:organization/webhooks - Available methods: GET, POST"))
+      Left(Seq(
+        "HTTP method 'OPTIONS' not defined for path '/:organization/webhooks' - Available methods: GET, POST, PUT, DELETE"
+      ))
     )
   }
 

--- a/src/test/scala/io/apibuilder/validation/MultiServiceSpec2.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceSpec2.scala
@@ -93,7 +93,7 @@ class MultiServiceSpec2 extends FunSpec with Matchers with helpers.Helpers {
   }
 
   it("correctly parses required fields") {
-    val orgModel = flowMultiService.findType("organization").headOption.get.asInstanceOf[ApibuilderType.Model].model
+    val orgModel = flowMultiService.findType("organization").headOption.get.asInstanceOf[ApiBuilderType.Model].model
     orgModel.fields.find(_.name == "id").get.required should be(true)
     orgModel.fields.find(_.name == "parent").get.required should be(false)
   }

--- a/src/test/scala/io/apibuilder/validation/MultiServiceSpec2.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceSpec2.scala
@@ -47,7 +47,7 @@ class MultiServiceSpec2 extends FunSpec with Matchers with helpers.Helpers {
     * validation methods (vs. correctly resolving service 1)
     */
   it("validates when path exists in both services with different available methods") {
-    flowMultiService.upcast(
+    flowMultiService.upcastOperationBody(
       "POST",
       "/:organization/payments",
       Json.obj(

--- a/src/test/scala/io/apibuilder/validation/MultiServiceSpecResolvesUrls.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceSpecResolvesUrls.scala
@@ -8,23 +8,23 @@ import play.api.libs.json.Json
 class MultiServiceSpecResolvesUrls extends FunSpec with Matchers with Helpers {
 
   it("validates unknown methods") {
-    flowMultiService.validate("FOO", "/test-org/payments") should equal(
+    flowMultiService.validateOperation("FOO", "/test-org/payments") should equal(
       Left(Seq("HTTP method 'FOO' is invalid. Must be one of: " + Method.all.map(_.toString).mkString(", ")))
     )
 
-    flowMultiService.validate("OPTIONS", "/test-org/payments") should equal(
+    flowMultiService.validateOperation("OPTIONS", "/test-org/payments") should equal(
       Left(Seq("HTTP method 'OPTIONS' not supported for path /test-org/payments - Available methods: GET, POST"))
     )
   }
 
   it("validates unknown paths") {
-    flowMultiService.validate("GET", "/foo") should equal(
+    flowMultiService.validateOperation("GET", "/foo") should equal(
       Left(Seq("HTTP path '/foo' is not defined"))
     )
   }
 
   it("validates unknown method for a known path") {
-    flowMultiService.validate("OPTIONS", "/users") should equal(
+    flowMultiService.validateOperation("OPTIONS", "/users") should equal(
       Left(Seq("HTTP method 'OPTIONS' not supported for path /users - Available methods: GET, POST"))
     )
   }
@@ -70,12 +70,12 @@ class MultiServiceSpecResolvesUrls extends FunSpec with Matchers with Helpers {
   }
 
   it("resolves static methods over dynamic ones") {
-    flowMultiService.asInstanceOf[MultiServiceImpl].resolveService(Method.Post, "/demo/tokens").right.get.service.name should equal("API")
+    flowMultiService.asInstanceOf[MultiServiceImpl].validateOperation(Method.Post, "/demo/tokens").right.get.service.name should equal("API")
     flowMultiService.bodyTypeFromPath("POST", "/:organization/tokens") should equal(
       Some("organization_token_form")
     )
 
-    flowMultiService.asInstanceOf[MultiServiceImpl].resolveService(Method.Post, "/users/tokens").right.get.service.name should equal("API Internal")
+    flowMultiService.asInstanceOf[MultiServiceImpl].validateOperation(Method.Post, "/users/tokens").right.get.service.name should equal("API Internal")
     flowMultiService.bodyTypeFromPath("POST", "/users/tokens") should equal(
       None
     )

--- a/src/test/scala/io/apibuilder/validation/MultiServiceSpecResolvesUrls.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceSpecResolvesUrls.scala
@@ -54,7 +54,7 @@ class MultiServiceSpecResolvesUrls extends FunSpec with Matchers with Helpers {
     * validation methods (vs. correctly resolving service 1)
     */
   it("validates when path exists in both services with different available methods") {
-    flowMultiService.upcast(
+    flowMultiService.upcastOperationBody(
       "POST",
       "/test-org/payments",
       Json.obj(

--- a/src/test/scala/io/apibuilder/validation/MultiServiceSpecResolvesUrls.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceSpecResolvesUrls.scala
@@ -9,7 +9,9 @@ class MultiServiceSpecResolvesUrls extends FunSpec with Matchers with Helpers {
 
   it("validates unknown methods") {
     flowMultiService.validateOperation("FOO", "/test-org/payments") should equal(
-      Left(Seq("HTTP method 'FOO' is invalid. Must be one of: " + Method.all.map(_.toString).mkString(", ")))
+      Left(Seq(
+        "HTTP method 'FOO' is invalid. Must be one of: " + Method.all.map(_.toString).mkString(", "))
+      )
     )
 
     flowMultiService.validateOperation("OPTIONS", "/test-org/payments") should equal(

--- a/src/test/scala/io/apibuilder/validation/MultiServiceZipSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceZipSpec.scala
@@ -74,7 +74,7 @@ class MultiServiceZipSpec extends FunSpec with Matchers
     val op = zipService.operation("POST", "/users").get.operation
     op.body.map(_.`type`) should equal(Some("user_form"))
     zipService.upcastOperationBody("POST", "/users", Json.obj("name" -> "test")) should equal(
-      Left(Seq("TODO"))
+      Left(Seq("user_form.name must be an object and not a string"))
     )
   }
 

--- a/src/test/scala/io/apibuilder/validation/MultiServiceZipSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceZipSpec.scala
@@ -42,10 +42,10 @@ class MultiServiceZipSpec extends FunSpec with Matchers
       case Left(errors) => sys.error(s"Failed to load $zipFile: $errors")
       case Right(ms) => ms
     }
-    multiService.findType(service1.service.models.head.name).headOption.getOrElse {
+    multiService.findType(service1.service.namespace, service1.service.models.head.name).getOrElse {
       sys.error("Failed to find service 1 model")
     }
-    multiService.findType(service2.service.models.head.name).headOption.getOrElse {
+    multiService.findType(service2.service.namespace, service2.service.models.head.name).getOrElse {
       sys.error("Failed to find service 2 model")
     }
   }
@@ -58,12 +58,12 @@ class MultiServiceZipSpec extends FunSpec with Matchers
   }
 
   it("performance is similar") {
-    zipService.validate("GET", "/users").right.get
-    flowMultiService.validate("GET", "/users").right.get
+    zipService.validateOperation("GET", "/users").right.get
+    flowMultiService.validateOperation("GET", "/users").right.get
 
     def run(service: MultiService) = {
       time(1000) {
-        service.validate("GET", "/users")
+        service.validateOperation("GET", "/users")
       }
     }
     run(flowMultiService) < 50 should be(true)
@@ -71,7 +71,7 @@ class MultiServiceZipSpec extends FunSpec with Matchers
   }
 
   it("upcast") {
-    val op = zipService.operation("POST", "/users").get
+    val op = zipService.operation("POST", "/users").get.operation
     op.body.map(_.`type`) should equal(Some("user_form"))
     zipService.upcast("POST", "/users", Json.obj("name" -> "test")) should equal(
       Left(Seq("TODO"))

--- a/src/test/scala/io/apibuilder/validation/MultiServiceZipSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceZipSpec.scala
@@ -14,6 +14,8 @@ class MultiServiceZipSpec extends FunSpec with Matchers
   with helpers.Helpers
 {
 
+  private[this] lazy val zipService = MultiService.fromUrl("https://cdn.flow.io/util/lib-apibuilder/specs.zip").right.get
+
   case class ServiceAndFile(service: Service, file: File)
 
   def createServiceAndWriteToFile(): ServiceAndFile = {
@@ -56,7 +58,6 @@ class MultiServiceZipSpec extends FunSpec with Matchers
   }
 
   it("performance is similar") {
-    val zipService = MultiService.fromUrl("https://cdn.flow.io/util/lib-apibuilder/specs.zip").right.get
     zipService.validate("GET", "/users").right.get
     flowMultiService.validate("GET", "/users").right.get
 
@@ -67,6 +68,14 @@ class MultiServiceZipSpec extends FunSpec with Matchers
     }
     run(flowMultiService) < 50 should be(true)
     run(zipService) < 50 should be(true)
+  }
+
+  it("upcast") {
+    val op = zipService.operation("POST", "/users").get
+    op.body.map(_.`type`) should equal(Some("user_form"))
+    zipService.upcast("POST", "/users", Json.obj("name" -> "test")) should equal(
+      Left(Seq("TODO"))
+    )
   }
 
   private[this] def time(numberIterations: Int)(f: => Any): Long = {

--- a/src/test/scala/io/apibuilder/validation/MultiServiceZipSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceZipSpec.scala
@@ -73,7 +73,7 @@ class MultiServiceZipSpec extends FunSpec with Matchers
   it("upcast") {
     val op = zipService.operation("POST", "/users").get.operation
     op.body.map(_.`type`) should equal(Some("user_form"))
-    zipService.upcast("POST", "/users", Json.obj("name" -> "test")) should equal(
+    zipService.upcastOperationBody("POST", "/users", Json.obj("name" -> "test")) should equal(
       Left(Seq("TODO"))
     )
   }

--- a/src/test/scala/io/apibuilder/validation/MultipleTypesWithSameNameSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultipleTypesWithSameNameSpec.scala
@@ -51,14 +51,14 @@ class MultipleTypesWithSameNameSpec extends FunSpec with Matchers
       )
     )
 
-    multi.validate(
+    multi.upcast(
       mustFindModel(multi, "item"),
       Json.obj("value" -> Json.obj())
     ) should equal(
       Left(Seq("Missing required field for price: amount"))
     )
 
-    multi.validate(
+    multi.upcast(
       mustFindModel(multi, "product"),
       Json.obj("value" -> Json.obj())
     ) should equal(

--- a/src/test/scala/io/apibuilder/validation/MultipleTypesWithSameNameSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultipleTypesWithSameNameSpec.scala
@@ -52,14 +52,14 @@ class MultipleTypesWithSameNameSpec extends FunSpec with Matchers
     )
 
     multi.upcast(
-      mustFindModel(multi, "item"),
+      mustFindModel(multi, service1.namespace, "item"),
       Json.obj("value" -> Json.obj())
     ) should equal(
       Left(Seq("Missing required field for price: amount"))
     )
 
     multi.upcast(
-      mustFindModel(multi, "product"),
+      mustFindModel(multi, service2.namespace, "product"),
       Json.obj("value" -> Json.obj())
     ) should equal(
       Left(Seq("Missing required fields for price: amount, currency"))

--- a/src/test/scala/io/apibuilder/validation/MultipleTypesWithSameNameSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultipleTypesWithSameNameSpec.scala
@@ -46,7 +46,7 @@ class MultipleTypesWithSameNameSpec extends FunSpec with Matchers
       )
     )
     val multi = MultiServiceImpl(
-      Seq(
+      List(
         ApiBuilderService(service1), ApiBuilderService(service2)
       )
     )

--- a/src/test/scala/io/apibuilder/validation/SerializationSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/SerializationSpec.scala
@@ -2,9 +2,9 @@ package io.apibuilder.validation
 
 import io.flow.v0.models.json._
 
-import io.flow.v0.models.{Image, ImageForm, ItemForm}
+import io.flow.v0.models.{ImageForm, ItemForm}
 import org.scalatest.{FunSpec, Matchers}
-import play.api.libs.json.{JsArray, JsObject, JsValue, Json}
+import play.api.libs.json.Json
 
 class SerializationSpec extends FunSpec with Matchers with helpers.Helpers {
 
@@ -34,8 +34,9 @@ class SerializationSpec extends FunSpec with Matchers with helpers.Helpers {
 
     val deserializedForm = rightOrErrors {
       flowMultiService.upcast(
-        "io.flow.v0",
-        "item_form",
+        flowMultiService.findType("io.flow.v0", "item_form").getOrElse {
+          sys.error("Could not find type")
+        },
         FormData.toJson(
           FormData.parseEncoded(encoded)
         )

--- a/src/test/scala/io/apibuilder/validation/SerializationSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/SerializationSpec.scala
@@ -34,6 +34,7 @@ class SerializationSpec extends FunSpec with Matchers with helpers.Helpers {
 
     val deserializedForm = rightOrErrors {
       flowMultiService.upcast(
+        "io.flow.v0",
         "item_form",
         FormData.toJson(
           FormData.parseEncoded(encoded)

--- a/src/test/scala/io/apibuilder/validation/helpers/ApiBuilderServiceHelpers.scala
+++ b/src/test/scala/io/apibuilder/validation/helpers/ApiBuilderServiceHelpers.scala
@@ -95,16 +95,13 @@ trait ApiBuilderServiceHelpers {
     Info(license = license, contact = contact)
   }
 
-  def mustFindModel(multi: MultiService, name: String): ApiBuilderType.Model = {
-    multi.findType(defaultNamespace = "", name).toList match {
-      case Nil => sys.error(s"Cannot find type $name")
-      case one :: Nil => {
-        one match {
-          case m: ApiBuilderType.Model => m
-          case _ => sys.error(s"Type '$name' is not a model")
-        }
-      }
-      case multiple => sys.error(s"Cannot find type $name - multiple matches: $multiple")
+  def mustFindModel(multi: MultiService, namespace: String, name: String): ApiBuilderType.Model = {
+    val t = multi.findType(defaultNamespace = namespace, name).getOrElse {
+      sys.error(s"Cannot find namespace[$namespace] name[$name]")
+    }
+    t match {
+      case m: ApiBuilderType.Model => m
+      case _ => sys.error(s"Type '$name' is not a model")
     }
   }
 

--- a/src/test/scala/io/apibuilder/validation/helpers/ApiBuilderServiceHelpers.scala
+++ b/src/test/scala/io/apibuilder/validation/helpers/ApiBuilderServiceHelpers.scala
@@ -96,12 +96,12 @@ trait ApiBuilderServiceHelpers {
   }
 
   def mustFindModel(multi: MultiService, name: String): ApiBuilderType.Model = {
-    multi.findType(name).toList match {
+    multi.findType(defaultNamespace = "", name).toList match {
       case Nil => sys.error(s"Cannot find type $name")
       case one :: Nil => {
         one match {
           case m: ApiBuilderType.Model => m
-          case other => sys.error(s"Type '$name' is not a model")
+          case _ => sys.error(s"Type '$name' is not a model")
         }
       }
       case multiple => sys.error(s"Cannot find type $name - multiple matches: $multiple")

--- a/src/test/scala/io/apibuilder/validation/helpers/ApiBuilderServiceHelpers.scala
+++ b/src/test/scala/io/apibuilder/validation/helpers/ApiBuilderServiceHelpers.scala
@@ -3,7 +3,7 @@ package io.apibuilder.validation.helpers
 import io.apibuilder.spec.v0.models._
 import java.util.UUID
 
-import io.apibuilder.validation.{ApibuilderType, MultiService}
+import io.apibuilder.validation.{ApiBuilderType, MultiService}
 
 trait ApiBuilderServiceHelpers {
   
@@ -95,12 +95,12 @@ trait ApiBuilderServiceHelpers {
     Info(license = license, contact = contact)
   }
 
-  def mustFindModel(multi: MultiService, name: String): ApibuilderType.Model = {
+  def mustFindModel(multi: MultiService, name: String): ApiBuilderType.Model = {
     multi.findType(name).toList match {
       case Nil => sys.error(s"Cannot find type $name")
       case one :: Nil => {
         one match {
-          case m: ApibuilderType.Model => m
+          case m: ApiBuilderType.Model => m
           case other => sys.error(s"Type '$name' is not a model")
         }
       }

--- a/src/test/scala/io/apibuilder/validation/helpers/Helpers.scala
+++ b/src/test/scala/io/apibuilder/validation/helpers/Helpers.scala
@@ -1,19 +1,17 @@
 package io.apibuilder.validation.helpers
 
+import java.io.File
+
 import io.apibuilder.spec.v0.models.Service
 import io.apibuilder.spec.v0.models.json._
+import io.apibuilder.validation.zip.FileUtil
 import io.apibuilder.validation.{ApiBuilderService, MultiService, MultiServiceImpl}
 import play.api.libs.json.Json
 
 trait Helpers {
 
   def readFile(filename: String): String = {
-    val source = scala.io.Source.fromFile("src/test/resources/" + filename, "UTF-8")
-    try {
-      source.getLines.mkString("\n")
-    } finally {
-      source.close()
-    }
+    FileUtil.readFileAsString(new File("src/test/resources/" + filename))
   }
 
   def loadService(filename: String): ApiBuilderService = {
@@ -22,13 +20,13 @@ trait Helpers {
     )
   }
 
-  def loadMultiService(files: Seq[String]): MultiService = {
+  def loadMultiService(files: List[String]): MultiService = {
     MultiServiceImpl(files.map(loadService))
   }
 
   lazy val apibuilderMultiService: MultiService = {
     loadMultiService(
-      Seq(
+      List(
         "apibuilder-explicit-validation-core-service.json",
         "apibuilder-explicit-validation-service.json"
       )
@@ -37,7 +35,7 @@ trait Helpers {
 
   lazy val flowMultiService: MultiService = {
     loadMultiService(
-      Seq(
+      List(
         "flow-api-service.json",
         "flow-api-internal-service.json"
       )


### PR DESCRIPTION
This is a large refactor of the MultiService interface.

The main change is to make sure when validating / upcasting, we always preserve the service in which we are operating which provides us a way to remove any ambiguity when resolving a type.