### PR TITLE
Update FormData to respect leading zeroes

### DIFF
--- a/src/main/scala/io/apibuilder/validation/FormData.scala
+++ b/src/main/scala/io/apibuilder/validation/FormData.scala
@@ -283,7 +283,7 @@ object FormData {
       case "true" => JsBoolean(true)
       case "false" => JsBoolean(false)
       case other => {
-        toNumber(other) match {
+        toLong(other) match {
           case Some(v) => JsNumber(v)
           case None => JsString(other)
         }
@@ -293,11 +293,11 @@ object FormData {
 
   private[this] val AcceptableRegexp = """^\-?[0-9]+$""".r
 
-  def toNumber(value: String): Option[BigDecimal] = {
+  def toLong(value: String): Option[Long] = {
     value match {
       case AcceptableRegexp() => {
         Try {
-          BigDecimal(value)
+          value.toLong
         } match {
           case Success(num) => {
             if (num.toString == value) {

--- a/src/main/scala/io/apibuilder/validation/FormData.scala
+++ b/src/main/scala/io/apibuilder/validation/FormData.scala
@@ -58,6 +58,7 @@ object FormData {
   ): String = {
     def urlEncode(s: String): String = java.net.URLEncoder.encode(s, Encoding)
     def encodeIt(value: String, keys: Seq[String]): String = encode(urlEncode(value), keys)
+
     js match {
       case o: JsObject => {
         o.value.map { case (key, value) =>
@@ -247,8 +248,6 @@ object FormData {
   // }
   @tailrec
   private[this] def toJsonObject(key: String, value: JsValue): JsObject = {
-    // println(s"toJsonObject key[$key] value: $value")
-
     key match {
       case EndsWithIndexInBrackets(prefix, index) => {
         // Fill in JsNull up to our desired index to preserve the explicit
@@ -300,7 +299,13 @@ object FormData {
         Try {
           BigDecimal(value)
         } match {
-          case Success(num) => Some(num)
+          case Success(num) => {
+            if (num.toString == value) {
+              Some(num)
+            } else {
+              None
+            }
+          }
           case Failure(_) => None
         }
       }

--- a/src/test/scala/io/apibuilder/validation/FormDataSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/FormDataSpec.scala
@@ -1,7 +1,5 @@
 package io.apibuilder.validation
 
-import java.io.File
-
 import org.scalatest.{FunSpec, Matchers}
 import play.api.libs.json._
 
@@ -14,6 +12,9 @@ class FormDataSpec extends FunSpec with Matchers {
     FormData.toNumber("-1") should be(Some(-1))
     FormData.toNumber("1999") should be(Some(1999))
     FormData.toNumber("-1999") should be(Some(-1999))
+    FormData.toNumber("0101") should be(None)
+    FormData.toNumber("0101.") should be(None)
+    FormData.toNumber("0101.00") should be(None)
   }
 
   it("parseEncoded") {
@@ -179,6 +180,23 @@ class FormDataSpec extends FunSpec with Matchers {
     it("handles empty strings") {
       val res = FormData.toJson(data).fields.find(_._1 == "anEmptyString")
       res should be(Some("anEmptyString" -> JsNull))
+    }
+
+    it("preserve leading zeroes") {
+      FormData.normalize(
+        Seq(
+          ("number1", "0100"),
+          ("number1", "0100."),
+          ("number2", "0100.10")
+        ),
+        options = Set(EncodingOptions.OmitArrayIndexes)
+      ) should equal(
+        Seq(
+          ("number1", "0100"),
+          ("number1", "0100."),
+          ("number2", "0100.10")
+        )
+      )
     }
 
     it("toJson for seq of tuples handles array bracket format") {

--- a/src/test/scala/io/apibuilder/validation/FormDataSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/FormDataSpec.scala
@@ -5,16 +5,23 @@ import play.api.libs.json._
 
 class FormDataSpec extends FunSpec with Matchers {
 
-  it("toNumber") {
-    FormData.toNumber("") should be(None)
-    FormData.toNumber("a") should be(None)
-    FormData.toNumber("1") should be(Some(1))
-    FormData.toNumber("-1") should be(Some(-1))
-    FormData.toNumber("1999") should be(Some(1999))
-    FormData.toNumber("-1999") should be(Some(-1999))
-    FormData.toNumber("0101") should be(None)
-    FormData.toNumber("0101.") should be(None)
-    FormData.toNumber("0101.00") should be(None)
+  it("toInteger") {
+    FormData.toLong("") should be(None)
+    FormData.toLong("a") should be(None)
+    FormData.toLong("1") should be(Some(1))
+    FormData.toLong("-1") should be(Some(-1))
+    FormData.toLong("1999") should be(Some(1999))
+    FormData.toLong("-1999") should be(Some(-1999))
+    FormData.toLong("0101") should be(None)
+    FormData.toLong("0101.") should be(None)
+    FormData.toLong("0101.00") should be(None)
+    FormData.toLong("0101.10") should be(None)
+    FormData.toLong("-0101.00") should be(None)
+    FormData.toLong("-0101.10") should be(None)
+    FormData.toLong("1999.10") should be(None)
+    FormData.toLong("1999.00") should be(None)
+    FormData.toLong("-1999.10") should be(None)
+    FormData.toLong("-1999.00") should be(None)
   }
 
   it("parseEncoded") {


### PR DESCRIPTION
This addresses a bug with the code automatically stripping out leading zeroes in a string with all numeric characters.

For example, if a parameter is of string text `0101`, we actually want to preserve `0101`. Instead, by trying to cast to `BigDecimal`, we unintentionally alter the data to `101`:

```
scala> val value = "0101"
value: String = 0101

scala> BigDecimal(value)
res2: scala.math.BigDecimal = 101
```

This causes issues for the api implementations downstream when we intend to use value `0101`, but instead get `101`.