### PR TITLE
Multiservice: validate primitive bodies

### DIFF
--- a/src/main/scala/io/apibuilder/validation/MultiServiceImpl.scala
+++ b/src/main/scala/io/apibuilder/validation/MultiServiceImpl.scala
@@ -23,8 +23,8 @@ case class MultiServiceImpl(
     validator.findType(typ).headOption
   }
 
-  override def upcast(typ: ApiBuilderType, js: JsValue): Either[Seq[String], JsValue] = {
-    validator.validateType(typ, js)
+  override def upcast(typ: String, defaultNamespace: String, js: JsValue): Either[Seq[String], JsValue] = {
+    validator.validate(typ, js, Some(defaultNamespace))
   }
 
 }

--- a/src/test/scala/io/apibuilder/validation/EnumValuesSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/EnumValuesSpec.scala
@@ -25,13 +25,9 @@ class EnumValuesSpec extends AnyFunSpec with Matchers with helpers.Helpers {
   }
 
   it("serialize enums with values") {
-    val fraudReview = flowMultiService.findType(
-      "io.flow.internal.v0", "fraud_review"
-    ).get
-
     def assertValid(value: String) = {
       rightOrErrors {
-        flowMultiService.upcast(fraudReview, makeFraudReview(value))
+        flowMultiService.upcast("fraud_review", "io.flow.internal.v0", makeFraudReview(value))
       }
     }
     assertValid("Low-Risk") // use enum_value.value

--- a/src/test/scala/io/apibuilder/validation/MultiServiceImplSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultiServiceImplSpec.scala
@@ -169,4 +169,14 @@ class MultiServiceImplSpec extends AnyFunSpec with Matchers with Helpers {
     )
   }
 
+  it("validates array types") {
+    multi.upcastOperationBody(
+      "PUT",
+      "/:organization/experiences/:experience_key/payment/method/rules",
+      Json.obj()
+    ) should equal(
+      Left(Seq("Missing required fields for experience_payment_method_rule_form: payment_method_id, tags"))
+    )
+  }
+
 }

--- a/src/test/scala/io/apibuilder/validation/MultipleTypesWithSameNameSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/MultipleTypesWithSameNameSpec.scala
@@ -53,14 +53,16 @@ class MultipleTypesWithSameNameSpec extends AnyFunSpec with Matchers
     )
 
     multi.upcast(
-      mustFindModel(multi, service1.namespace, "item"),
+      "item",
+      service1.namespace,
       Json.obj("value" -> Json.obj())
     ) should equal(
       Left(Seq("Missing required field for price: amount"))
     )
 
     multi.upcast(
-      mustFindModel(multi, service2.namespace, "product"),
+      "product",
+      service2.namespace,
       Json.obj("value" -> Json.obj())
     ) should equal(
       Left(Seq("Missing required fields for price: amount, currency"))

--- a/src/test/scala/io/apibuilder/validation/SerializationSpec.scala
+++ b/src/test/scala/io/apibuilder/validation/SerializationSpec.scala
@@ -35,9 +35,8 @@ class SerializationSpec extends AnyFunSpec with Matchers with helpers.Helpers {
 
     val deserializedForm = rightOrErrors {
       flowMultiService.upcast(
-        flowMultiService.findType("io.flow.v0", "item_form").getOrElse {
-          sys.error("Could not find type")
-        },
+        "item_form",
+        "io.flow.v0",
         FormData.toJson(
           FormData.parseEncoded(encoded)
         )


### PR DESCRIPTION
Use case here is to validate bodies that are expected to be arrays. If something else is passed instead, apibuilder-validation looks for a ApiBuilderType (model, enum, union), cannot find the array type, and just forwards it to the service, which returns a deserialization error.

This breaks the lib's api, I will need to make changes to proxy as well.