### PR TITLE
FDN-3650: fix import for Scala 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,11 @@ lazy val root = project
   .settings(
     testOptions += Tests.Argument("-oF"),
     libraryDependencies ++= Seq(
-      "com.github.apicollective" % "apibuilder-commons" % (if (scalaVersion.value.startsWith("3")) "0.1.0" else "0.0.6"),
+      if (scalaVersion.value.startsWith("3")) {
+        "com.github.apicollective" % "apibuilder-commons" % "0.1.0"
+      } else {
+        "io.apibuilder" % "apibuilder-commons" % "0.0.6"
+      },
       "com.typesafe.play" %% "play-json" % (if (scalaVersion.value.startsWith("3")) "2.10.6" else "2.9.4"),
       "com.typesafe.play" %% "play-json-joda" % (if (scalaVersion.value.startsWith("3")) "2.10.6" else "2.9.4"),
       "org.apache.commons" % "commons-compress" % "1.26.2",


### PR DESCRIPTION
I think when the version was upgraded to 0.1.0, the organization part of the import also changed, see: https://github.com/apicollective/apibuilder-validation/commit/75aa1daebfc0395d81fb82c3edaa082622c0d449#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91L17-L38.